### PR TITLE
Move web scraper services from frontend to backend

### DIFF
--- a/backend/services/README.md
+++ b/backend/services/README.md
@@ -24,7 +24,8 @@ A comprehensive web scraping service for extracting content from job posting URL
 - `puppeteer-scraper.ts` - JavaScript-heavy site scraper using Puppeteer
 - `playwright-scraper.ts` - Most reliable scraper using Playwright (final fallback)
 - `scraper-utils.ts` - Utility functions and error handling
-- `web-scraper.example.ts` - Usage examples
+- `smart-scraper.ts` - Smart scraper with LinkedIn/Facebook detection
+- `api-integration.example.ts` - Usage examples
 
 ## Installation
 
@@ -39,7 +40,7 @@ npx playwright install chromium
 ## Basic Usage
 
 ```typescript
-import { scrapeUrl } from '@/lib/services';
+import { scrapeUrl } from '@/backend/services';
 
 // Scrape a URL (automatic fallback chain)
 const result = await scrapeUrl('https://example.com/job-posting');
@@ -59,7 +60,7 @@ if (result.success) {
 ### Custom Timeout
 
 ```typescript
-import { scrapeUrl } from '@/lib/services/web-scraper';
+import { scrapeUrl } from '@/backend/services/web-scraper';
 
 const result = await scrapeUrl('https://example.com/job', {
   timeout: 60000, // 60 seconds
@@ -69,7 +70,7 @@ const result = await scrapeUrl('https://example.com/job', {
 ### Force Puppeteer
 
 ```typescript
-import { scrapeUrl } from '@/lib/services/web-scraper';
+import { scrapeUrl } from '@/backend/services/web-scraper';
 
 const result = await scrapeUrl('https://example.com/job', {
   forcePuppeteer: true, // Always use Puppeteer
@@ -79,7 +80,7 @@ const result = await scrapeUrl('https://example.com/job', {
 ### Force Specific Scraper
 
 ```typescript
-import { scrapeUrl } from '@/lib/services';
+import { scrapeUrl } from '@/backend/services';
 
 // Force Cheerio only
 const cheerioResult = await scrapeUrl('https://example.com/job', {
@@ -105,7 +106,7 @@ const noPlaywrightResult = await scrapeUrl('https://example.com/job', {
 ### Scrape Multiple URLs
 
 ```typescript
-import { scrapeMultipleUrls } from '@/lib/services/web-scraper';
+import { scrapeMultipleUrls } from '@/backend/services/web-scraper';
 
 const urls = [
   'https://example.com/job1',
@@ -127,7 +128,7 @@ results.forEach((result, index) => {
 ### Cleanup Resources
 
 ```typescript
-import { cleanup } from '@/lib/services/web-scraper';
+import { cleanup } from '@/backend/services/web-scraper';
 
 // When done with all scraping
 await cleanup();
@@ -180,7 +181,7 @@ Clean up browser instances and resources.
 The scraper provides comprehensive error handling:
 
 ```typescript
-import { scrapeUrl, ScraperError } from '@/lib/services/web-scraper';
+import { scrapeUrl, ScraperError } from '@/backend/services/web-scraper';
 
 try {
   const result = await scrapeUrl('https://example.com/job');
@@ -241,7 +242,7 @@ The scraper automatically detects common job posting platforms that require Java
 Example integration with Gemini for job parsing:
 
 ```typescript
-import { scrapeUrl, cleanup } from '@/lib/services/web-scraper';
+import { scrapeUrl, cleanup } from '@/backend/services/web-scraper';
 import { parseJobPosting } from '@/lib/ai/gemini';
 
 async function submitJobUrl(url: string) {
@@ -346,3 +347,4 @@ const result = await scrapeUrl(url, { timeout: 60000 });
 ## License
 
 Part of the GDG Opportunities Platform project.
+

--- a/backend/services/api-integration.example.ts
+++ b/backend/services/api-integration.example.ts
@@ -292,3 +292,4 @@ export function handleScraperError(error: unknown): {
     message: 'Internal server error',
   };
 }
+

--- a/backend/services/cheerio-scraper.ts
+++ b/backend/services/cheerio-scraper.ts
@@ -249,3 +249,4 @@ export async function canScrapeWithCheerio(url: string): Promise<boolean> {
     return false;
   }
 }
+

--- a/backend/services/index.ts
+++ b/backend/services/index.ts
@@ -65,3 +65,4 @@ export type {
 export { canScrapeWithCheerio } from './cheerio-scraper';
 export { scrapeMultipleWithPuppeteer, takeScreenshot as takeScreenshotWithPuppeteer } from './puppeteer-scraper';
 export { scrapeMultipleWithPlaywright, takeScreenshot as takeScreenshotWithPlaywright, getPageHTML } from './playwright-scraper';
+

--- a/backend/services/playwright-scraper.ts
+++ b/backend/services/playwright-scraper.ts
@@ -346,3 +346,4 @@ export async function getPageHTML(
     }
   }
 }
+

--- a/backend/services/puppeteer-scraper.ts
+++ b/backend/services/puppeteer-scraper.ts
@@ -279,3 +279,4 @@ export async function takeScreenshot(
     }
   }
 }
+

--- a/backend/services/scraper-utils.ts
+++ b/backend/services/scraper-utils.ts
@@ -200,3 +200,4 @@ export const DEFAULT_TIMEOUT = 30000; // 30 seconds
  */
 export const DEFAULT_USER_AGENT =
   'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
+

--- a/backend/services/smart-scraper.ts
+++ b/backend/services/smart-scraper.ts
@@ -224,3 +224,4 @@ export async function exampleUsage(url: string, manualContent?: string) {
     error: result.error,
   };
 }
+

--- a/backend/services/web-scraper.ts
+++ b/backend/services/web-scraper.ts
@@ -124,8 +124,6 @@ export async function scrapeUrl(
           fallbackChain,
         };
       }
-
-      console.log(`Cheerio failed for ${url} (content: ${cheerioResult.content.length} chars), trying Puppeteer...`);
     }
 
     // Step 2: Try Puppeteer
@@ -144,8 +142,6 @@ export async function scrapeUrl(
         fallbackChain,
       };
     }
-
-    console.log(`Puppeteer failed for ${url} (content: ${puppeteerResult.content.length} chars), trying Playwright (final fallback)...`);
 
     // Step 3: Try Playwright (final fallback)
     if (!options.disablePlaywrightFallback) {
@@ -246,3 +242,4 @@ export { validateUrl, isJavaScriptHeavySite, ScraperError } from './scraper-util
 export { scrapeWithCheerio } from './cheerio-scraper';
 export { scrapeWithPuppeteer, closeBrowser as closePuppeteerBrowser } from './puppeteer-scraper';
 export { scrapeWithPlaywright, closeBrowser as closePlaywrightBrowser } from './playwright-scraper';
+

--- a/frontend/app/api/test-scraper/route.ts
+++ b/frontend/app/api/test-scraper/route.ts
@@ -1,4 +1,4 @@
-import { scrapeUrl } from '@/lib/services';
+import { scrapeUrl } from '@/backend/services';
 import { NextResponse } from 'next/server';
 
 export async function GET(request: Request) {

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,8 +1,55 @@
+const path = require('path')
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
   images: {
     domains: [],
+  },
+  webpack: (config, { isServer }) => {
+    // Ensure modules are resolved from frontend node_modules
+    // This is needed when importing from backend folder
+    if (isServer) {
+      const originalResolveModules = config.resolve.modules || []
+      config.resolve.modules = [
+        path.resolve(__dirname, 'node_modules'),
+        ...originalResolveModules.filter(m => !m.includes('node_modules')),
+      ]
+      
+      // Exclude server-side dependencies from webpack bundling
+      // They should be loaded at runtime from node_modules
+      const serverOnlyModules = [
+        'playwright',
+        'puppeteer', 
+        'playwright-core',
+        'cheerio',
+        'htmlparser2',
+        'entities',
+      ]
+      
+      config.externals = config.externals || []
+      if (Array.isArray(config.externals)) {
+        config.externals.push(...serverOnlyModules)
+      } else if (typeof config.externals === 'function') {
+        const originalExternals = config.externals
+        config.externals = [
+          originalExternals,
+          ({ request }, callback) => {
+            if (serverOnlyModules.includes(request)) {
+              return callback(null, `commonjs ${request}`)
+            }
+            callback()
+          },
+        ]
+      } else {
+        config.externals = [
+          config.externals,
+          ...serverOnlyModules,
+        ]
+      }
+    }
+    
+    return config
   },
 }
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1493,6 +1493,7 @@
       "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.81.1.tgz",
       "integrity": "sha512-KSdY7xb2L0DlLmlYzIOghdw/na4gsMcqJ8u4sD6tOQJr+x3hLujU9s4R8N3ob84/1bkvpvlU5PYKa1ae+OICnw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@supabase/auth-js": "2.81.1",
         "@supabase/functions-js": "2.81.1",
@@ -1581,6 +1582,7 @@
       "integrity": "sha512-RFA/bURkcKzx/X9oumPG9Vp3D3JUgus/d0b67KB0t5S/raciymilkOa66olh78MUI92QLbEJevO7rvqU/kjwKA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -1592,6 +1594,7 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -1776,6 +1779,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2346,6 +2350,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -2781,7 +2786,8 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.0.tgz",
       "integrity": "sha512-si++xzRAY9iPp60roQiFta7OFbhrgvcthrhlNAGeQptSY25uJjkfUV8OArC3KLocB8JT8ohz+qgxWCmz8RhjIg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -2947,7 +2953,8 @@
       "version": "0.0.1521046",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1521046.tgz",
       "integrity": "sha512-vhE6eymDQSKWUXwwA37NtTTVEzjtGVfDr3pRbsWEQ5onH/Snp2c+2xZHWJJawG/0hCCJLRGt4xVtEVUVILol4w==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -3355,6 +3362,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3523,6 +3531,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5083,6 +5092,7 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -6007,6 +6017,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -6293,6 +6304,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -6305,6 +6317,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -6318,6 +6331,7 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.66.0.tgz",
       "integrity": "sha512-xXBqsWGKrY46ZqaHDo+ZUYiMUgi8suYu5kdrS20EG8KiL7VRQitEbNjm+UcrDYrNi1YLyfpmAeGjCZYXLT9YBw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -7265,6 +7279,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.18.tgz",
       "integrity": "sha512-6A2rnmW5xZMdw11LYjhcI5846rt9pbLSabY5XPxo+XWdxwZaFEn47Go4NzFiHu9sNNmr/kXivP1vStfvMaK1GQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -7437,6 +7452,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7610,6 +7626,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -19,7 +19,8 @@
       }
     ],
     "paths": {
-      "@/*": ["./*"]
+      "@/*": ["./*"],
+      "@/backend/*": ["../backend/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
- Moved all scraper files from frontend/lib/services to backend/services
- Updated import paths to use @/backend/services
- Added path alias in tsconfig.json for backend imports
- Configured Next.js webpack to resolve modules from backend folder
- Externalized server-side dependencies (playwright, puppeteer, cheerio) in webpack config
- All scraper functionality tested and working correctly