### PR TITLE
feat: Add real-time statistics to homepage

### DIFF
--- a/frontend/app/api/stats/route.ts
+++ b/frontend/app/api/stats/route.ts
@@ -1,0 +1,80 @@
+import { NextResponse } from "next/server"
+import { createClient } from "@/lib/supabase/server"
+
+export const dynamic = 'force-dynamic'
+
+export async function GET() {
+  try {
+    const supabase = createClient()
+
+    // Calculate date ranges
+    const now = new Date()
+    const sevenDaysAgo = new Date(now)
+    sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7)
+    
+    const thirtyDaysFromNow = new Date(now)
+    thirtyDaysFromNow.setDate(thirtyDaysFromNow.getDate() + 30)
+
+    // Format dates for Supabase queries
+    // For created_at (timestamp), use full ISO string
+    const sevenDaysAgoISO = sevenDaysAgo.toISOString()
+    // For deadline (date), use date string (YYYY-MM-DD)
+    const nowDateStr = now.toISOString().split('T')[0]
+    const thirtyDaysFromNowDateStr = thirtyDaysFromNow.toISOString().split('T')[0]
+
+    // Fetch all three stats in parallel
+    const [
+      newThisWeekResult,
+      deadlinesThisMonthResult,
+      activeListingsResult,
+    ] = await Promise.all([
+      // New This Week: opportunities created in last 7 days with active status
+      supabase
+        .from("opportunities")
+        .select("id", { count: "exact", head: true })
+        .eq("status", "active")
+        .gte("created_at", sevenDaysAgoISO),
+      
+      // Deadlines This Month: opportunities with deadlines in next 30 days and active status
+      supabase
+        .from("opportunities")
+        .select("id", { count: "exact", head: true })
+        .eq("status", "active")
+        .not("deadline", "is", null)
+        .gte("deadline", nowDateStr)
+        .lte("deadline", thirtyDaysFromNowDateStr),
+      
+      // Active Listings: all active opportunities
+      supabase
+        .from("opportunities")
+        .select("id", { count: "exact", head: true })
+        .eq("status", "active"),
+    ])
+
+    // Handle errors gracefully
+    if (newThisWeekResult.error) {
+      console.error("Failed to fetch new this week count:", newThisWeekResult.error)
+    }
+    if (deadlinesThisMonthResult.error) {
+      console.error("Failed to fetch deadlines this month count:", deadlinesThisMonthResult.error)
+    }
+    if (activeListingsResult.error) {
+      console.error("Failed to fetch active listings count:", activeListingsResult.error)
+    }
+
+    return NextResponse.json({
+      newThisWeek: newThisWeekResult.count || 0,
+      deadlinesThisMonth: deadlinesThisMonthResult.count || 0,
+      activeListings: activeListingsResult.count || 0,
+    })
+  } catch (error) {
+    console.error("Stats API error:", error)
+    // Return zeros on error so the page still renders
+    return NextResponse.json({
+      newThisWeek: 0,
+      deadlinesThisMonth: 0,
+      activeListings: 0,
+    })
+  }
+}
+

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { useState, useEffect } from "react"
 import Navbar from "@/components/layout/Navbar"
 import Footer from "@/components/layout/Footer"
 import Link from "next/link"
@@ -7,7 +8,7 @@ import Image from "next/image"
 import { motion } from "framer-motion"
 import { 
   Zap, 
-  Users, 
+  Calendar,
   Briefcase, 
   Lightbulb, 
   Beaker, 
@@ -16,12 +17,58 @@ import {
   ArrowRight
 } from "lucide-react"
 
+interface StatsData {
+  newThisWeek: number
+  deadlinesThisMonth: number
+  activeListings: number
+}
+
 export default function Home() {
-  const stats = [
-    { icon: Zap, value: "12,345+", label: "Total Opportunities" },
-    { icon: Users, value: "50,000+", label: "Active Users" },
-    { icon: Briefcase, value: "15+", label: "Opportunity Types" },
-  ]
+  const [statsData, setStatsData] = useState<StatsData | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+
+  useEffect(() => {
+    const fetchStats = async () => {
+      try {
+        const response = await fetch("/api/stats")
+        if (response.ok) {
+          const data = await response.json()
+          setStatsData(data)
+        }
+      } catch (error) {
+        console.error("Failed to fetch stats:", error)
+        // Set default values on error
+        setStatsData({
+          newThisWeek: 0,
+          deadlinesThisMonth: 0,
+          activeListings: 0,
+        })
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    fetchStats()
+  }, [])
+
+  // Format number with commas
+  const formatNumber = (num: number | null | undefined): string => {
+    if (num === null || num === undefined) return "0"
+    return num.toLocaleString("en-US")
+  }
+
+  // Build stats array with real data
+  const stats = statsData
+    ? [
+        { icon: Zap, value: formatNumber(statsData.newThisWeek), label: "New This Week" },
+        { icon: Calendar, value: formatNumber(statsData.deadlinesThisMonth), label: "Deadlines This Month" },
+        { icon: Briefcase, value: formatNumber(statsData.activeListings), label: "Active Listings" },
+      ]
+    : [
+        { icon: Zap, value: isLoading ? "—" : "0", label: "New This Week" },
+        { icon: Calendar, value: isLoading ? "—" : "0", label: "Deadlines This Month" },
+        { icon: Briefcase, value: isLoading ? "—" : "0", label: "Active Listings" },
+      ]
 
   const opportunityTypes = [
     { name: "Internships", href: "/dashboard?type=internship" },


### PR DESCRIPTION
- Create public stats API endpoint (/api/stats)
- Replace hardcoded stats with real-time data from database
- Show 'New This Week', 'Deadlines This Month', and 'Active Listings'

<img width="1437" height="623" alt="Screenshot 2025-11-19 at 9 46 52 PM" src="https://github.com/user-attachments/assets/c8d378ab-dc34-464b-a6c5-32d32b78f1a4" />
