### PR TITLE
Fix: Use service role key for public stats API to bypass RLS

### DIFF
--- a/frontend/app/api/stats/route.ts
+++ b/frontend/app/api/stats/route.ts
@@ -1,11 +1,30 @@
 import { NextResponse } from "next/server"
-import { createClient } from "@/lib/supabase/server"
+import { createClient } from "@supabase/supabase-js"
 
 export const dynamic = 'force-dynamic'
 
 export async function GET() {
   try {
-    const supabase = createClient()
+    // Use service role key to bypass RLS for public stats
+    // This is safe because we're only returning counts, not sensitive data
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+    const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+    if (!supabaseUrl || !supabaseServiceKey) {
+      console.error("Missing Supabase environment variables")
+      return NextResponse.json({
+        newThisWeek: 0,
+        deadlinesThisMonth: 0,
+        activeListings: 0,
+      })
+    }
+
+    const supabase = createClient(supabaseUrl, supabaseServiceKey, {
+      auth: {
+        autoRefreshToken: false,
+        persistSession: false
+      }
+    })
 
     // Calculate date ranges
     const now = new Date()


### PR DESCRIPTION
- Changed stats API to use SUPABASE_SERVICE_ROLE_KEY instead of anon key
- Safe because we only return counts, not sensitive data
- Fixes issue where regular users saw 0, 0, 0 on homepage

<img width="1450" height="622" alt="Screenshot 2025-11-20 at 2 15 17 PM" src="https://github.com/user-attachments/assets/c24416f1-a439-4daa-a293-078fb0279c67" />
