### PR TITLE
fix: Force light mode on auth pages (login, signup, forgot/reset pass…

### DIFF
--- a/frontend/app/(auth)/layout.tsx
+++ b/frontend/app/(auth)/layout.tsx
@@ -1,0 +1,30 @@
+'use client'
+
+import { useEffect } from 'react'
+
+export default function AuthLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  // Force light mode for auth pages by temporarily overriding the theme
+  useEffect(() => {
+    const root = document.documentElement
+    const originalClasses = root.className
+
+    // Remove dark class and ensure light mode
+    root.classList.remove('dark')
+    root.classList.add('light')
+
+    // Restore original classes when leaving auth pages
+    return () => {
+      root.className = originalClasses
+    }
+  }, [])
+
+  return (
+    <div className="light" data-theme="light">
+      {children}
+    </div>
+  )
+}

--- a/frontend/app/reset-password/page.tsx
+++ b/frontend/app/reset-password/page.tsx
@@ -17,6 +17,19 @@ export default function ResetPasswordPage() {
   const [showPassword, setShowPassword] = useState(false)
   const [showConfirmPassword, setShowConfirmPassword] = useState(false)
 
+  // Force light mode for reset password page
+  useEffect(() => {
+    const root = document.documentElement
+    const originalClasses = root.className
+
+    root.classList.remove('dark')
+    root.classList.add('light')
+
+    return () => {
+      root.className = originalClasses
+    }
+  }, [])
+
   // Verify the session on mount
   useEffect(() => {
     const verifySession = async () => {


### PR DESCRIPTION
…word)

Auth pages now maintain consistent light mode appearance regardless of user's theme preference. Added layout wrapper for (auth) route group and useEffect hook for reset-password page to force light theme.